### PR TITLE
Servir receta a un paciente desde la vista Farmacia

### DIFF
--- a/src/main/java/es/uvigo/esei/dagss/controladores/atencion_paciente/AtencionPacienteControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/atencion_paciente/AtencionPacienteControlador.java
@@ -7,6 +7,7 @@ package es.uvigo.esei.dagss.controladores.atencion_paciente;
 
 import es.uvigo.esei.dagss.controladores.autenticacion.AutenticacionControlador;
 import es.uvigo.esei.dagss.dominio.daos.RecetaDAO;
+import es.uvigo.esei.dagss.dominio.entidades.Farmacia;
 import es.uvigo.esei.dagss.dominio.entidades.Receta;
 import java.io.Serializable;
 import java.util.List;
@@ -19,7 +20,7 @@ import javax.inject.Named;
  *
  * @author José Angel
  */
-@Named()
+@Named
 @SessionScoped
 public class AtencionPacienteControlador implements Serializable {
     
@@ -67,5 +68,10 @@ public class AtencionPacienteControlador implements Serializable {
         return "index";
     }
     
- 
+    public String doServirRecetaPaciente(Receta receta, Farmacia farmaciaDispensadora){
+        recetaDAO.servirRecetas(receta,farmaciaDispensadora);
+        recetas = recetaDAO.buscarRecetasNts(getNts());
+        return "index";
+    }
+    
 }

--- a/src/main/java/es/uvigo/esei/dagss/dominio/daos/RecetaDAO.java
+++ b/src/main/java/es/uvigo/esei/dagss/dominio/daos/RecetaDAO.java
@@ -4,13 +4,16 @@
 
 package es.uvigo.esei.dagss.dominio.daos;
 
-import es.uvigo.esei.dagss.dominio.entidades.Paciente;
+
+import es.uvigo.esei.dagss.dominio.entidades.EstadoReceta;
+import es.uvigo.esei.dagss.dominio.entidades.Farmacia;
 import es.uvigo.esei.dagss.dominio.entidades.Receta;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
 @Stateless
@@ -27,4 +30,10 @@ public class RecetaDAO extends GenericoDAO<Receta>{
         q.setParameter("fecha_actual", fecha_actual);
         return q.getResultList();
     }
+    
+    public void servirRecetas(Receta receta,Farmacia farmaciaDispensadora){
+        receta.setFarmaciaDispensadora(farmaciaDispensadora);
+        receta.setEstadoReceta(EstadoReceta.SERVIDA);
+        actualizar(receta);
+    };
 }

--- a/src/main/webapp/farmacia/privado/index.xhtml
+++ b/src/main/webapp/farmacia/privado/index.xhtml
@@ -21,14 +21,14 @@
             <ui:define name="contenido">
                 <h:form id="searchForm">
                     <b:column offset="2" span="8">
-                        <b:panel title="Buscar recetas" look="primary" collapsible="false">
+                        <b:panel title="Buscar recetas" look="primary" collapsible="false" >
                             <b:inputText id="nts" label="Nº Tarjeta Sanitaria:" value="#{atencionPacienteControlador.nts}" />
                             <b:commandButton id="searchButton" value="Buscar" action="#{atencionPacienteControlador.doBuscarRecetasEnVigor()}" span="2"/>
                         </b:panel>
                     </b:column> 
                     
                     <b:column offset="2" span="8"> 
-                        <h2>#{atencionPacienteControlador.nombre_paciente}</h2>
+                        <h2 id="nombre-paciente">Paciente: #{atencionPacienteControlador.nombre_paciente}</h2>
                      </b:column> 
 
                     <b:column offset="2" span="8">                        
@@ -48,28 +48,28 @@
                             <h:column>
                                 <f:facet name="header"><h:outputLabel value="Inicio Validez"/></f:facet>
                                 <h:outputText id="inicio_validez" value="#{receta.inicioValidez}" >
-                                    <f:convertDateTime pattern="dd/MM/yyyy" />
+                                    <f:convertDateTime timeZone="CET" pattern="dd/MM/yyyy" />
                                 </h:outputText>
                             </h:column>
                             
                             <h:column>
                                 <f:facet name="header"><h:outputLabel value="Fin Validez"/></f:facet>
                                 <h:outputText id="fin_validez" value="#{receta.finValidez}" >
-                                    <f:convertDateTime pattern="dd/MM/yyyy" />
+                                    <f:convertDateTime timeZone="CET" pattern="dd/MM/yyyy"/>
                                 </h:outputText>
                             </h:column>
                             
                             <h:column>
                                 <f:facet name="header"><h:outputLabel value="Estado"/></f:facet>
-                                <h:outputText value="#{receta.estadoReceta}" />
+                                <h:outputText id="estadoReceta" value="#{receta.estadoReceta}" />
                             </h:column>
                             
                             <h:column class="text-center">
                                 <f:facet name="header"><h:outputLabel value="Servir"/></f:facet>
-                                <h:commandLink id="servir-icon" action="#{atencionPacienteControlador}">
-           
-                                </h:commandLink>
+                                <h:commandButton id="servir-button" value="Servir" 
+                                                 action="#{atencionPacienteControlador.doServirRecetaPaciente(receta,farmaciaControlador.farmaciaActual)}" />
                             </h:column>
+                            
                         </b:dataTable>
                         
                     </b:column>

--- a/src/main/webapp/resources/js/custom_style.js
+++ b/src/main/webapp/resources/js/custom_style.js
@@ -1,14 +1,21 @@
-$( document ).ready(function() {    
+$( document ).ready(function() {  
+    //VISTA FARMACIA
+        //Obtener número de tablas
         var $rows = ($("[id='searchForm:lista_recetas'] tbody tr")).length;
+        //Limpiar nombre de paciente
+        if($rows===0){
+            $("#nombre-paciente").empty();
+        }
         var $hoy = new Date().getTime();
         for (var i = 0, max = $rows; i < max; i++) {
+            var $estadoReceta = $("[id='searchForm:lista_recetas:"+i+":estadoReceta']").text();
             var $inicio = formatearFecha($("[id='searchForm:lista_recetas:"+i+":inicio_validez']").text());
             var $fin = formatearFecha($("[id='searchForm:lista_recetas:"+i+":fin_validez']").text());
 
-            if($hoy >= $inicio && $hoy<$fin){
-                $("[id='searchForm:lista_recetas:"+i+":servir-icon']").html('<span><i id="searchForm:lista_recetas:0:j_idt41" class="fa fa-check"></i></span>');  
+            if ($hoy >= $inicio && $hoy<$fin && $estadoReceta!=="SERVIDA"){
+                $("[id='searchForm:lista_recetas:"+i+":servir-button']").attr("class","btn btn-primary");  
             }else{
-                $("[id='searchForm:lista_recetas:"+i+":servir-icon']").html('<span><i id="searchForm:lista_recetas:0:j_idt41" class="disabled fa fa-close"></i></span>');  
+                $("[id='searchForm:lista_recetas:"+i+":servir-button']").attr("class","btn disabled");
             }
         }     
    });


### PR DESCRIPTION
Permitir a una Farmacia servir una Receta a un Paciente. Para ello se ha creado un método de actualización en RecetaDAO que es invocado desde el controlador AtencionPacienteControlador. En él se asigna la farmacia dispensadora que realiza la acción y se actualiza el estado de la receta a "SERVIDA".
Dadas las confusiones de la anterior interfaz, se ha mejorado consiguiendo el siguiente aspecto:

![image](https://user-images.githubusercontent.com/10835920/33553381-c89af0c8-d8f8-11e7-822f-038c82983e47.png)

